### PR TITLE
web-xml patch

### DIFF
--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -35,23 +35,15 @@
    <servlet>
         <servlet-name>hello_servlet</servlet-name>
 	    <servlet-class>HelloServlet</servlet-class>
-
+   </servlet>
+   <servlet>
         <servlet-name>login</servlet-name>
 	    <servlet-class>Login</servlet-class>
-
-
+   </servlet>
+   <servlet>
         <servlet-name>profile</servlet-name>
 	    <servlet-class>Profile</servlet-class>
-
-
-	<!-- Contains a name/value pair as an initialization
-	     attribute of the servlet -->
-        <init-param>
-            <param-name>value_name</param-name>
-            <param-value>10</param-value>
-        </init-param>
-
-    </servlet>
+   </servlet>
 
 
     <!--  Servlet and JSPs can access this data using getServletContext().method
@@ -67,13 +59,16 @@
     <servlet-mapping>
         <servlet-name>hello_servlet</servlet-name>
         <url-pattern>/hello</url-pattern>
+    </servlet-mapping>
 
+    <servlet-mapping>
         <servlet-name>profile</servlet-name>
         <url-pattern>/profile</url-pattern>
+    </servlet-mapping>
 
+    <servlet-mapping>
         <servlet-name>login</servlet-name>
         <url-pattern>/login</url-pattern>
-
     </servlet-mapping>
 
 


### PR DESCRIPTION
The issue #19 is due to an oversight: each servlet and servlet-mapping must be put in a different block like so:
```xml
<servlet>
    <servlet-name>hello_servlet</servlet-name>
    <servlet-class>HelloServlet</servlet-class>
</servlet>
<servlet>
    <servlet-name>login</servlet-name>
    <servlet-class>Login</servlet-class>
</servlet>
<servlet>
    <servlet-name>profile</servlet-name>
    <servlet-class>Profile</servlet-class>
</servlet>
```

This patch closes #19 
Tests were done before PR