### PR TITLE
Added urlEncoding

### DIFF
--- a/src/main/java/Login.java
+++ b/src/main/java/Login.java
@@ -76,10 +76,13 @@ public class Login extends HttpServlet {
         synchronized(session) {
             session.setAttribute("name", name);
         }
-
-        // Redirect to another page
-        // req.getRequestDispatcher("./HelloServlet").forward(req, res);
-        res.sendRedirect("/risto89-1.0/profile");
+        
+        // Encode the Session ID in the URL, this allows
+        // the use of the Session when cookies are disabled
+        String encodedURL = res.encodeURL("/risto89-1.0/profile");
+        
+        // Redirect
+        res.sendRedirect(encodedURL);
     }
     else {
     	res.sendRedirect("/risto89-1.0/login");


### PR DESCRIPTION
This PR implements URL encoding to address #26 , and It works for the current state of the application where the only api accessible only with a session is /profile. For future pages, we should be careful testing without cookies. From my tests, getSession() takes the JSESSIONID from both cookie and url, this means we will need to use encodeURL() on any page that redirects to another if the JSESSION id if found in the url and not in the cookie.