### PR TITLE
Patched error page

### DIFF
--- a/src/main/java/Error.java
+++ b/src/main/java/Error.java
@@ -18,7 +18,7 @@ public class Error extends HttpServlet {
   {
 
     res.setCharacterEncoding("UTF-8");
-    req.getRequestDispatcher("./Errorpage.jsp").include(req, res);
+    req.getRequestDispatcher("/Errorpage.jsp").include(req, res);
   }
 
   @Override

--- a/src/main/java/Error.java
+++ b/src/main/java/Error.java
@@ -3,15 +3,29 @@ import java.io.*;
 import javax.servlet.http.*;
 import javax.servlet.*;
 
+// This Servlet handles the error page
+// You need to pass the error message as a parameter
+// like so:
+//
+// req.setAttribute("error", "Non hai ancora fatto il login!");
+// req.getRequestDispatcher("./error").forward(req,res);
 public class Error extends HttpServlet {
+
+  @Override
   public void doGet (HttpServletRequest req,
                      HttpServletResponse res)
     throws ServletException, IOException
   {
+
     res.setCharacterEncoding("UTF-8");
+    req.getRequestDispatcher("./Errorpage.jsp").include(req, res);
+  }
 
-    req.getRequestDispatcher("./Errorpage.jsp").include(req, res); //Print the jasper page
-
-        
+  @Override
+  public void doPost (HttpServletRequest req,
+                      HttpServletResponse res)
+    throws ServletException, IOException
+  {
+    doGet(req, res);
   }
 }


### PR DESCRIPTION
When sending a request to the error page with
```java
req.getRequestDispatcher("./error").forward(req, res);
```
The error page would not work. Apparently getRequestDispatcher() performs a post which is not supported by the current implementation of the error page. This patch fixes this.