### PR TITLE
Fixed web.xml regression, indentation and a case of relative path

### DIFF
--- a/src/main/java/Error.java
+++ b/src/main/java/Error.java
@@ -18,7 +18,7 @@ public class Error extends HttpServlet {
   {
 
     res.setCharacterEncoding("UTF-8");
-    req.getRequestDispatcher("./Errorpage.jsp").include(req, res);
+    req.getRequestDispatcher("/Errorpage.jsp").include(req, res);
   }
 
   @Override

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -57,8 +57,8 @@
    </servlet>
 
    <servlet>
-       <servlet-name>testdb</servlet-name>
-       <servlet-class>TestDB</servlet-class>
+        <servlet-name>testdb</servlet-name>
+        <servlet-class>TestDB</servlet-class>
    </servlet>
 
 
@@ -90,35 +90,37 @@
 
     <servlet-mapping>
         <servlet-name>error</servlet-name>
-	<url-pattern>/error</url-pattern>
+	    <url-pattern>/error</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-      <servlet-name>testdb</servlet-name>
-	    <url-pattern>/testdb</url-pattern>
+        <servlet-name>testdb</servlet-name>
+        <url-pattern>/testdb</url-pattern>
+    </servlet-mapping>
 
-      <servlet-name>logout</servlet-name>
-      <url-pattern>/logout</url-pattern>
+    <servlet-mapping>
+        <servlet-name>logout</servlet-name>
+        <url-pattern>/logout</url-pattern>
     </servlet-mapping>
 
 
     <!-- Filters config -->
     <filter>
-            <filter-name>AuthenticationFilter</filter-name>
-            <filter-class>AuthenticationFilter</filter-class>
+        <filter-name>AuthenticationFilter</filter-name>
+        <filter-class>AuthenticationFilter</filter-class>
     </filter>
 
 
     <!-- Url to map the filter onto -->
     <filter-mapping>
-            <filter-name>AuthenticationFilter</filter-name>
-            <url-pattern>/profile</url-pattern>
+        <filter-name>AuthenticationFilter</filter-name>
+        <url-pattern>/profile</url-pattern>
     </filter-mapping>
 
 
    <!-- Setup Session -->
    <session-config>
-           <session-timeout>2</session-timeout>
+        <session-timeout>2</session-timeout>
    </session-config>
 
 </web-app>


### PR DESCRIPTION
There was a missing `<servlet-mapping>` line that made `/testdb` and `/logout` unavaiable. The regression is fixed and I made improvements in indentation and fixed an urgent problem with relative vs absolute path for the Error page