### PR TITLE
51 make the header show profile actions correctly

### DIFF
--- a/src/main/java/Login.java
+++ b/src/main/java/Login.java
@@ -94,7 +94,8 @@ public class Login extends HttpServlet {
   		     HttpServletResponse res)
      throws ServletException, IOException
   {
-    req.getRequestDispatcher("/Loginpage.html").include(req, res);
+    res.setCharacterEncoding("UTF-8");
+    req.getRequestDispatcher("/Loginpage.jsp").include(req, res);
 
   }
 }

--- a/src/main/webapp/Header.jsp
+++ b/src/main/webapp/Header.jsp
@@ -22,10 +22,20 @@
                 </li>
             </ul>
             <ul class="navbar-nav">
+                <% 
+	        String name = (String) session.getAttribute("name");
+	        if(name == null){
+	        %>
+	        <li class ="nav-item">
+                    <a class="nav-link active" aria-current="page" href="./login">Login</a>
+	        <%
+	        }else{
+	        %>
                 <li class ="nav-item">
-		<%--TODO Check if the user is already logged in, if so then don't show "login" button--%>
-                    <a class="nav-link active" aria-current="page" href="./Loginpage.jsp">Login</a>
-                </li>
+                    <a class="nav-link active" aria-current="page" href="./logout">Logout</a>
+	        <%
+	        }
+	        %>
             </ul>
         </div>
     </div>

--- a/src/main/webapp/Login.js
+++ b/src/main/webapp/Login.js
@@ -1,0 +1,8 @@
+function makePasswordVisible(){
+    var passwordBox = document.getElementById("passwordInput");
+    if (passwordBox.type === "password"){
+    	passwordBox.type = "text";
+    }else{
+	passwordBox.type = "password";
+    }
+}

--- a/src/main/webapp/Loginpage.jsp
+++ b/src/main/webapp/Loginpage.jsp
@@ -26,7 +26,7 @@
 	<div>
             <form action="./login" method="post">
                 <input type="text" name="name" label="Inserisci lo username" required>
-                <input type="text" name="password" label="Inserisci la password" required>
+                <input type="password" name="password" label="Inserisci la password" required>
                 <input type="submit" value="Fai il login">
             </form>
         </div>

--- a/src/main/webapp/Loginpage.jsp
+++ b/src/main/webapp/Loginpage.jsp
@@ -3,7 +3,8 @@
 <!DOCTYPE html>
 
 <html lang="en">
-   
+    <%-- Include JS file into the page --%>
+    <script type="text/javascript" src="./Login.js"></script>
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -26,9 +27,12 @@
 	<div>
             <form action="./login" method="post">
                 <input type="text" name="name" label="Inserisci lo username" required>
-                <input type="password" name="password" label="Inserisci la password" required>
+                <input id="passwordInput" type="password" name="password" label="Inserisci la password" required>
                 <input type="submit" value="Fai il login">
             </form>
+	    <br>
+	    <input type="checkbox" onclick="makePasswordVisible()" name="Showpassword">
+	    <label for"Showpassword"> Mostra la password </label>
         </div>
       
 	<!--PAGE CONTENT-->

--- a/src/main/webapp/Profile.jsp
+++ b/src/main/webapp/Profile.jsp
@@ -16,9 +16,8 @@
 
 
         <!--PAGE CONTENT-->
-
-        <% String name = (String) session.getAttribute("name"); %>
-        
+   
+   	<%-- "name" variable defined in "Header.jsp" --%>
 	<div>
 	    <% if (name == null){%>
 	        <p>Non hai ancora fatto il login!</p>


### PR DESCRIPTION
Fixes #51 and #54 

To correctly show the "Login" or "Logout" button, the `Header.jsp` gets the session attribute called "name" and checks if it exists.
- If it does, then "Logout" is shown, which sends the user to `/logout` when clicked.
- If it doesn't, then "Login" is shown, which sends the user to `/login` when clicked.

<br>
<br>

In the `/login` page, the password form was made to be invisible by default, showing the character "*" instead of any other, that is unless the user himself checks the box "Mostrami la password", which makes the password visible.


When the checkbox is clicked, a JavaScript function is called, so a new file called `Login.js` was made


The function inside `Login.js` is very simple, gets the password box by his id ("passwordInput") and checks wether his state is showing the password or not by checking if his type is:

- "text": the password is being shown clear, changes its type into "password".
- "password": the password is being hidden, changes its type to "text.